### PR TITLE
Rework decoding and opcode definition to allow for Mod R/M groups to be properly handled

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -31,9 +31,10 @@ fn u8_from_bytes(bytes: &[u8]) -> Result<u8, VMError>{
 
 #[derive(Default)]
 #[derive(Debug)]
-struct ModRM{
+#[derive(Clone, Copy)]
+pub struct ModRM{
     rm: u8, //3 bits
-    reg: u8, //3 bits
+    pub reg: u8, //3 bits
     mode: u8, //2 bits
 }
 
@@ -103,7 +104,8 @@ impl ModRM{
 }
 
 #[derive(Default)]
-struct SIB{
+#[derive(Clone, Copy)]
+pub struct SIB{
     base: u8, //3 bits
     index: u8, //3 bits
     scale: u8 //2 bits
@@ -119,7 +121,56 @@ impl SIB{
     }
 }
 
-pub fn decode_args(opcode: &Opcode, bytestream: &[u8], args: &mut [OpArgument; MAX_ARGS], _address_override: bool) -> Result<usize, VMError>{
+#[derive(Default)]
+#[derive(Clone, Copy)]
+pub struct ParsedModRM{
+    pub modrm: ModRM,
+    pub sib: Option<SIB>,
+    pub disp: Option<u32>,
+    pub size: u8
+}
+
+impl ParsedModRM{
+    pub fn from_bytes(bytestream: &[u8]) -> Result<ParsedModRM, VMError>{
+        if bytestream.len() < 16{
+            return Err(VMError::DecodingOverrun);
+        }
+        let mut parsed = ParsedModRM::default();
+        let mut sib = SIB::default();
+        let mut bytes = &bytestream[1..]; //skip opcode
+        let mut size = 0;
+        parsed.modrm = self::ModRM::parse(bytes[0]);
+        bytes = &bytes[1..]; //advance to next byte
+        size += 1;
+        if parsed.modrm.mode != 3 && parsed.modrm.rm == 4 {
+            sib = SIB::parse(bytes[0]);
+            parsed.sib = Some(sib);
+            bytes = &bytes[1..];
+            size += 1;
+        }
+        //read in immediate displacement
+        //first do 32 bit displacements
+        if  (parsed.modrm.mode == 0 && parsed.modrm.rm == 5) ||
+            (parsed.modrm.mode == 2) ||
+            (parsed.modrm.mode == 0 && parsed.sib.unwrap_or_default().base == 5) {
+            
+            parsed.disp = Some(u32_from_bytes(bytes)?);
+            bytes = &bytes[4..];
+            size += 4;
+        } else if parsed.modrm.mode == 1 {
+            parsed.disp = Some(((u8_from_bytes(bytes)? as i8) as i32) as u32);
+            bytes = &bytes[1..];
+            size += 1;
+        }
+        parsed.size = size;
+        Ok(parsed)
+    }
+}
+
+pub fn decode_args(opcode: &Opcode, bytestream: &[u8], args: &mut [OpArgument; MAX_ARGS], address_override: bool) -> Result<usize, VMError>{
+    decode_args_with_modrm(opcode, bytestream, args, address_override, None)
+}
+pub fn decode_args_with_modrm(opcode: &Opcode, bytestream: &[u8], args: &mut [OpArgument; MAX_ARGS], _address_override: bool, parsed_modrm: Option<ParsedModRM>) -> Result<usize, VMError>{
     use ArgSource::*;
     if bytestream.len() < 16{
         return Err(VMError::DecodingOverrun);
@@ -127,35 +178,10 @@ pub fn decode_args(opcode: &Opcode, bytestream: &[u8], args: &mut [OpArgument; M
     let opcode_byte = bytestream[0];
     let mut bytes = &bytestream[1..];
     let mut size:usize = 1; //to count for opcode
-    let mut modrm = self::ModRM::default();
-    let mut sib = SIB::default();
+    let modrm = parsed_modrm.unwrap_or_default();
+    size += modrm.size as usize;
+    bytes = &bytes[modrm.size as usize..];
     //note displacements are treated as signed numbers
-    let mut modrm_disp:u32 = 0;
-
-    if opcode.has_modrm{
-        modrm = self::ModRM::parse(bytes[0]);
-        bytes = &bytes[1..]; //advance to next byte
-        size += 1;
-        if modrm.mode != 3 && (modrm.rm == 4){
-            sib = SIB::parse(bytes[0]);
-            bytes = &bytes[1..];
-            size += 1;
-        }
-        //read in immediate displacement
-        //first do 32 bit displacements
-        if  (modrm.mode == 0 && modrm.rm == 5) ||
-            (modrm.mode == 2) ||
-            (modrm.mode == 0 && sib.base == 5) {
-            
-            modrm_disp = u32_from_bytes(bytes)?;
-            bytes = &bytes[4..];
-            size += 4;
-        } else if modrm.mode == 1 {
-            modrm_disp = ((u8_from_bytes(bytes)? as i8) as i32) as u32;
-            bytes = &bytes[1..];
-            size += 1;
-        }
-    }
     //todo: parse modr/m byte here if present, before actually parsing arguments
     for n in 0..3{
         let advance = match opcode.arg_source[n] {
@@ -163,11 +189,11 @@ pub fn decode_args(opcode: &Opcode, bytestream: &[u8], args: &mut [OpArgument; M
                 0
             },
             ModRM => {
-                args[n].location = modrm.decode(&sib, modrm_disp, opcode.arg_size[n]);
+                args[n].location = modrm.modrm.decode(&modrm.sib.unwrap_or_default(), modrm.disp.unwrap_or(0), opcode.arg_size[n]);
                 0 //size calculation was done before here, so don't need to advance any
             },
             ModRMReg => {
-                args[n].location = ArgLocation::RegisterValue(modrm.reg, opcode.arg_size[n]);
+                args[n].location = ArgLocation::RegisterValue(modrm.modrm.reg, opcode.arg_size[n]);
                 0
             },
             ImmediateAddress =>{
@@ -190,6 +216,10 @@ pub fn decode_args(opcode: &Opcode, bytestream: &[u8], args: &mut [OpArgument; M
             },
             RegisterSuffix =>{
                 args[n].location = ArgLocation::RegisterValue(opcode_byte & 0x7, opcode.arg_size[n]);
+                0
+            }
+            Literal(l) => {
+                args[n].location = ArgLocation::Immediate(l);
                 0
             }
         };
@@ -230,9 +260,10 @@ mod tests {
         let mut opcode:Opcode = Default::default();
         opcode.arg_source[0] = source;
         opcode.arg_size[0] = size;
-        opcode.has_modrm = true;
+
+        let modrm = ParsedModRM::from_bytes(bytecode).unwrap();
         
-        let res = match decode_args(&opcode, bytecode, &mut args, false){
+        let res = match decode_args_with_modrm(&opcode, bytecode, &mut args, false, Some(modrm)){
             Err(_) => {
                 assert!(false, "decode resulted in error");
                 0

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -136,15 +136,13 @@ impl ParsedModRM{
             return Err(VMError::DecodingOverrun);
         }
         let mut parsed = ParsedModRM::default();
-        let mut sib = SIB::default();
         let mut bytes = &bytestream[1..]; //skip opcode
         let mut size = 0;
         parsed.modrm = self::ModRM::parse(bytes[0]);
         bytes = &bytes[1..]; //advance to next byte
         size += 1;
         if parsed.modrm.mode != 3 && parsed.modrm.rm == 4 {
-            sib = SIB::parse(bytes[0]);
-            parsed.sib = Some(sib);
+            parsed.sib = Some(SIB::parse(bytes[0]));
             bytes = &bytes[1..];
             size += 1;
         }
@@ -155,11 +153,9 @@ impl ParsedModRM{
             (parsed.modrm.mode == 0 && parsed.sib.unwrap_or_default().base == 5) {
             
             parsed.disp = Some(u32_from_bytes(bytes)?);
-            bytes = &bytes[4..];
             size += 4;
         } else if parsed.modrm.mode == 1 {
             parsed.disp = Some(((u8_from_bytes(bytes)? as i8) as i32) as u32);
-            bytes = &bytes[1..];
             size += 1;
         }
         parsed.size = size;

--- a/src/opcodes.rs
+++ b/src/opcodes.rs
@@ -17,7 +17,8 @@ pub enum ArgSource{
     ImmediateAddress, //known as an "offset" in docs rather than pointer or address
     RegisterSuffix, //lowest 3 bits of the opcode is used for register
     //note: for Jump opcodes, exactly 1 argument is the only valid encoding
-    JumpRel
+    JumpRel,
+    Literal(SizedValue) //For encoding hard-coded values, such as the `rol modrm8, 1` opcode
 }
 
 #[derive(PartialEq)]
@@ -36,12 +37,19 @@ pub struct Opcode{
     pub function: OpcodeFn,
     pub arg_size: [ValueSize; MAX_ARGS],
     pub arg_source: [ArgSource; MAX_ARGS],
-    pub has_modrm: bool,
     pub gas_cost: i32,
-    pub rep_valid: bool,
-    pub size_override_valid: bool,
-    pub jump_behavior: JumpBehavior,
+    pub pipeline_behavior: JumpBehavior,
     pub defined: bool
+}
+
+#[derive(Copy, Clone)]
+pub struct OpcodeProperties{
+    pub has_modrm: bool,
+    pub defined: bool,
+    //pub rep_valid: bool, //this is handled in decoding by special case checking -- 0xA4 through 0xAF, excluding 0xA8 and 0xA9
+    //0 is the normal opcode, while the entire array is used for "group" opcodes which use the reg
+    //field of Mod R/M to extend the opcode
+    pub opcodes: [Opcode; 8],
 }
 
 pub fn nop(_vm: &mut VM, _pipeline: &Pipeline) -> Result<(), VMError>{
@@ -51,60 +59,57 @@ pub fn op_undefined(_vm: &mut VM, _pipeline: &Pipeline) -> Result<(), VMError>{
     Err(VMError::InvalidOpcode)
 }
 
+impl Default for OpcodeProperties{
+    fn default() -> OpcodeProperties{
+        OpcodeProperties{
+            has_modrm: false,
+            defined: false,
+            opcodes: [Opcode::default(); 8],
+        }
+    }
+}
+
 impl Default for Opcode{
     fn default() -> Opcode{
         Opcode{
             function: op_undefined,
             arg_size: [ValueSize::None, ValueSize::None, ValueSize::None],
             arg_source: [ArgSource::None, ArgSource::None, ArgSource::None],
-            has_modrm: false,
             gas_cost: 0,
-            rep_valid: false,
-            size_override_valid: false,
-            jump_behavior: JumpBehavior::None,
+            //this defaults to conditional so that an unknown opcode is considered conditional
+            pipeline_behavior: JumpBehavior::Conditional,
             defined: false
         }
     }
 }
-pub const OPCODE_TABLE_SIZE:usize = 0x1FFF;
-const OP_TWOBYTE:usize = 1 << 11;
-const OP_OVERRIDE:usize = 1 << 12;
-const OP_GROUP_SHIFT:u8 = 8;
+//index: lower byte is primary opcode
+//upper bit is if 0x0F prefix is used (ie, extended opcode)
+pub const OPCODE_TABLE_SIZE:usize = 0x1FF;
+const OP_TWOBYTE:usize = 1 << 8;
 
-//helper functions for opcode map
-fn with_override(op: usize) -> usize{
-    op | OP_OVERRIDE
-}
 fn two_byte(op: usize) -> usize{
     op | OP_TWOBYTE
 }
-fn with_group(op:usize, group: usize) -> usize{
-    if group > 7 {
-        panic!("Group opcode error in opcode initialization");
-    }
-    op | (group << OP_GROUP_SHIFT)
-}
 fn fill_groups(ops: &mut [Opcode], op:usize){
     for n in 0..8 {
-        ops[with_group(op, n)] = ops[op];
+        //ops[op].function = ops[op];
     }
 }
 fn fill_override(ops: &mut [Opcode], op:usize){
-    ops[with_override(op)] = ops[op];
+    //ops[with_override(op)] = ops[op];
 }
 fn fill_override_groups(ops: &mut [Opcode], op:usize){
     fill_groups(ops, op);
     fill_override(ops, op);
-    fill_groups(ops, with_override(op));
+    //fill_groups(ops, with_override(op));
 }
 
 
 
 #[derive(Default)]
-struct OpcodeDefiner{
+pub struct OpcodeDefiner{
     opcode: u8,
     //None = handle both with/without size override, false = without size override, true = with size override
-    size_override: Option<bool>,
     two_byte: bool,
     group: Option<u8>,
     gas_level: u32, //todo, make enum?
@@ -112,29 +117,20 @@ struct OpcodeDefiner{
     function: Option<OpcodeFn>,
     jump: Option<JumpBehavior>,
     has_modrm: bool,
-    has_rep: bool,
     reg_suffix: bool
 }
 
 impl OpcodeDefiner{
-    fn is_group(&mut self, group: u8) -> &mut OpcodeDefiner{
+    pub fn is_group(&mut self, group: u8) -> &mut OpcodeDefiner{
         self.group = Some(group);
         self.has_modrm = true;
         self
     }
-    fn calls(&mut self, function: OpcodeFn) -> &mut OpcodeDefiner{
+    pub fn calls(&mut self, function: OpcodeFn) -> &mut OpcodeDefiner{
         self.function = Some(function);
         self
     }
-    fn with_override(&mut self) -> &mut OpcodeDefiner{
-        self.size_override = Some(true);
-        self
-    }
-    fn without_override(&mut self) -> &mut OpcodeDefiner{
-        self.size_override = Some(false);
-        self
-    }
-    fn has_arg(&mut self, source: ArgSource, size: ValueSize) -> &mut OpcodeDefiner{
+    pub fn has_arg(&mut self, source: ArgSource, size: ValueSize) -> &mut OpcodeDefiner{
         
         let hasmodrm = match source{
             ArgSource::ModRMReg | ArgSource::ModRM => true,
@@ -147,24 +143,20 @@ impl OpcodeDefiner{
         self.args.push((source, size));
         self
     }
-    fn is_jump(&mut self) -> &mut OpcodeDefiner{
+    pub fn is_jump(&mut self) -> &mut OpcodeDefiner{
         self.jump = Some(JumpBehavior::Relative);
         self
     }
-    fn is_conditional(&mut self) -> &mut OpcodeDefiner{
+    pub fn is_conditional(&mut self) -> &mut OpcodeDefiner{
         self.jump = Some(JumpBehavior::Conditional);
         self
     }
-    fn with_rep(&mut self) -> &mut OpcodeDefiner{
-        self.has_rep = true;
-        self
-    }
-    fn with_gas(&mut self, gas: u32) -> &mut OpcodeDefiner{
+    pub fn with_gas(&mut self, gas: u32) -> &mut OpcodeDefiner{
         self.gas_level = gas;
         self
     }
 
-    fn into_table(&mut self, table: &mut [Opcode]){
+    pub fn into_table(&mut self, table: &mut [OpcodeProperties]){
         if self.jump.is_none(){
             self.jump = Some(JumpBehavior::None);
         }
@@ -175,49 +167,42 @@ impl OpcodeDefiner{
         };
         for n in 0..limit {
             let mut op = self.opcode as usize + n;
-            op = match self.size_override{
-                None => op,
-                Some(x) => {
-                    if x{
-                        with_override(op)
-                    }else{
-                        op
-                    }
-                }
+            op = match self.two_byte{
+                true => op | OP_TWOBYTE,
+                false => op
             };
+            if table[op].defined && !table[op].has_modrm{
+                panic!("Conflicting opcode definition detected");
+            }
             table[op].defined = true;
-            table[op].function = self.function.unwrap();
-            table[op].gas_cost = self.gas_level as i32;
-            table[op].jump_behavior = self.jump.unwrap();
-            for n in 0..self.args.len(){
-                let (source, size) = self.args[n];
-                table[op].arg_source[n] = source;
-                table[op].arg_size[n] = size;
-            }
             table[op].has_modrm = self.has_modrm;
-            table[op].rep_valid = self.has_rep;
-            if self.group.is_none() {
-                fill_groups(table, op);
-            }
-            //todo: add group stuff for else
-            if self.size_override.is_none(){
-                //if none, then assume this opcode defines both with and without override versions
-                fill_override(table, op);
-                if !self.group.is_none(){
-                    fill_groups(table, with_override(op));
-                }
+
+            //write to all 8 inner opcodes if has_modrm and no group
+            //Otherwise write to just the group inner opcode
+            let op_limit = if self.has_modrm && self.group.is_none(){
+                8
             }else{
-                if self.size_override.unwrap(){
-                    if !self.group.is_none(){
-                        fill_groups(table, op);
-                    }
+                1
+            };
+            let op_start = self.group.unwrap_or(0) as usize;
+            for inner in op_start..op_limit{
+                if table[op].opcodes[inner].defined {
+                    panic!("Conflicting opcode definition detected");
+                }
+                table[op].opcodes[inner].defined = true;
+                table[op].opcodes[inner].function = self.function.unwrap();
+                table[op].opcodes[inner].gas_cost = self.gas_level as i32;
+                table[op].opcodes[inner].pipeline_behavior = self.jump.unwrap();
+                for n in 0..self.args.len(){
+                    let (source, size) = self.args[n];
+                    table[op].opcodes[inner].arg_source[n] = source;
+                    table[op].opcodes[inner].arg_size[n] = size;
                 }
             }
         }
     }
-    
 }
-fn define_opcode(opcode: u8) -> OpcodeDefiner{
+pub fn define_opcode(opcode: u8) -> OpcodeDefiner{
     let mut d = OpcodeDefiner::default();
     //d.args.resize(3, (ArgSource::None, ValueSize::None));
     d.opcode = opcode;
@@ -238,9 +223,9 @@ In addition, all test code comments and other annotations should use the intel a
 
 //(Eventually) huge opcode map
 lazy_static! {
-    pub static ref OPCODES: [Opcode; OPCODE_TABLE_SIZE] = {
+    pub static ref OPCODES: [OpcodeProperties; OPCODE_TABLE_SIZE] = {
         use crate::ops::*;
-        let mut ops: [Opcode; OPCODE_TABLE_SIZE] = [Opcode::default(); OPCODE_TABLE_SIZE];
+        let mut ops: [OpcodeProperties; OPCODE_TABLE_SIZE] = [OpcodeProperties::default(); OPCODE_TABLE_SIZE];
         //nop
         define_opcode(0x90).calls(nop).with_gas(0).into_table(&mut ops);
 

--- a/src/opcodes.rs
+++ b/src/opcodes.rs
@@ -94,24 +94,6 @@ impl Default for Opcode{
 pub const OPCODE_TABLE_SIZE:usize = 0x1FF;
 const OP_TWOBYTE:usize = 1 << 8;
 
-fn two_byte(op: usize) -> usize{
-    op | OP_TWOBYTE
-}
-fn fill_groups(ops: &mut [Opcode], op:usize){
-    for n in 0..8 {
-        //ops[op].function = ops[op];
-    }
-}
-fn fill_override(ops: &mut [Opcode], op:usize){
-    //ops[with_override(op)] = ops[op];
-}
-fn fill_override_groups(ops: &mut [Opcode], op:usize){
-    fill_groups(ops, op);
-    fill_override(ops, op);
-    //fill_groups(ops, with_override(op));
-}
-
-
 
 #[derive(Default)]
 pub struct OpcodeDefiner{

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -32,7 +32,7 @@ pub fn clear_pipeline(pipeline: &mut [Pipeline]){
     }
 }
 
-pub fn fill_pipeline(vm: &VM, opcodes: &[Opcode], pipeline: &mut [Pipeline]) -> Result<(), VMError>{
+pub fn fill_pipeline(vm: &VM, opcodes: &[OpcodeProperties], pipeline: &mut [Pipeline]) -> Result<(), VMError>{
     let mut eip = vm.eip;
     let mut stop_filling = false;
     //writeable if in memory with top bit set
@@ -46,18 +46,25 @@ pub fn fill_pipeline(vm: &VM, opcodes: &[Opcode], pipeline: &mut [Pipeline]) -> 
             p.gas_cost = 0;
         }else{
             let buffer = vm.memory.get_sized_memory(eip, 16)?;
-            //todo: handle the upper bits of opcode
-            let opcode = &opcodes[buffer[0 as usize] as usize];
-            match opcode.jump_behavior{
+            //todo: handle 0x0F extension prefix and other prefixes
+            let prop = &opcodes[buffer[0 as usize] as usize];
+            let mut modrm = Option::None;
+            let opcode = if prop.has_modrm{
+                modrm = Some(ParsedModRM::from_bytes(buffer)?);
+                &prop.opcodes[modrm.unwrap().modrm.reg as usize]
+            }else{
+                &prop.opcodes[0]
+            };
+            match opcode.pipeline_behavior{
                 JumpBehavior::None => {
                     p.function = opcode.function;
                     p.gas_cost = opcode.gas_cost;
-                    p.eip_size = decode_args(opcode, buffer, &mut p.args, false)? as u8;
+                    p.eip_size = decode_args_with_modrm(opcode, buffer, &mut p.args, false, modrm)? as u8;
                 },
                 JumpBehavior::Conditional => {
                     p.function = opcode.function;
                     p.gas_cost = opcode.gas_cost;
-                    p.eip_size = decode_args(opcode, buffer, &mut p.args, false)? as u8;
+                    p.eip_size = decode_args_with_modrm(opcode, buffer, &mut p.args, false, modrm)? as u8;
                     eip += p.eip_size as u32;
                     stop_filling = true;
                 },
@@ -66,7 +73,7 @@ pub fn fill_pipeline(vm: &VM, opcodes: &[Opcode], pipeline: &mut [Pipeline]) -> 
                     //right now this is just copy-pasted from conditional jumps
                     p.function = opcode.function;
                     p.gas_cost = opcode.gas_cost;
-                    p.eip_size = decode_args(opcode, buffer, &mut p.args, false)? as u8;
+                    p.eip_size = decode_args_with_modrm(opcode, buffer, &mut p.args, false, modrm)? as u8;
                     eip += p.eip_size as u32;
                     stop_filling = true;
                 }
@@ -99,33 +106,32 @@ mod tests{
     0x03 (imm32), 50 gas -- test3_op, conditional jump behavior
     0x10 + r (reg32, off32), 23 gas -- test2_op
     */
-    fn test_opcodes() -> Vec<Opcode>{
-        let mut opcodes = vec![];
-        opcodes.resize(OPCODE_TABLE_SIZE, Opcode::default());
-        opcodes[0x01].gas_cost = 10;
-        opcodes[0x01].function = test_op;
-        
-        opcodes[0x02].arg_source[0] = ArgSource::ImmediateValue;
-        opcodes[0x02].arg_size[0] = ValueSize::Byte;
-        opcodes[0x02].gas_cost = 2;
-        opcodes[0x02].function = nop;
-        
-        opcodes[0x03].arg_source[0] = ArgSource::JumpRel;
-        opcodes[0x03].arg_size[0] = ValueSize::Dword;
-        opcodes[0x03].jump_behavior = JumpBehavior::Conditional;
-        opcodes[0x03].function = test3_op;
-        opcodes[0x03].gas_cost = 50;
+    fn test_opcodes() -> [OpcodeProperties; OPCODE_TABLE_SIZE]{
+        let mut table = [OpcodeProperties::default(); OPCODE_TABLE_SIZE];
 
-        for n in 0..8{
-            opcodes[0x10 + n].arg_source[0] = ArgSource::RegisterSuffix;
-            opcodes[0x10 + n].arg_source[1] = ArgSource::ImmediateAddress;
-            opcodes[0x10 + n].arg_size[0] = ValueSize::Dword;
-            opcodes[0x10 + n].arg_size[1] = ValueSize::Dword;
-            opcodes[0x10 + n].gas_cost = 23;
-            opcodes[0x10 + n].function = test2_op;
-        }
+        define_opcode(0x01)
+            .with_gas(10)
+            .calls(test_op)
+            .into_table(&mut table);
+        define_opcode(0x02)
+            .has_arg(ArgSource::ImmediateValue, ValueSize::Byte)
+            .with_gas(2)
+            .calls(nop)
+            .into_table(&mut table);
+        define_opcode(0x03)
+            .has_arg(ArgSource::JumpRel, ValueSize::Dword)
+            .is_conditional()
+            .with_gas(50)
+            .calls(test3_op)
+            .into_table(&mut table);
+        define_opcode(0x10)
+            .has_arg(ArgSource::RegisterSuffix, ValueSize::Dword)
+            .has_arg(ArgSource::ImmediateAddress, ValueSize::Dword)
+            .with_gas(23)
+            .calls(test2_op)
+            .into_table(&mut table);
 
-        opcodes
+        table
     }
 
     #[test]
@@ -161,7 +167,7 @@ mod tests{
         vm.eip += pipeline[0].eip_size as u32 + pipeline[1].eip_size as u32;
         fill_pipeline(&vm, &opcodes, &mut pipeline).unwrap();
 
-        assert!(pipeline[0].function as usize == test2_op as usize);
+        assert_eq!(pipeline[0].function as usize, test2_op as usize);
         assert!(pipeline[0].args[0].location == ArgLocation::RegisterValue(2, ValueSize::Dword));
         assert!(pipeline[0].args[1].location == ArgLocation::Address(0x44332211, ValueSize::Dword));
         assert!(pipeline[0].eip_size == 5); 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -56,19 +56,19 @@ pub fn fill_pipeline(vm: &VM, opcodes: &[OpcodeProperties], pipeline: &mut [Pipe
                 &prop.opcodes[0]
             };
             match opcode.pipeline_behavior{
-                JumpBehavior::None => {
+                PipelineBehavior::None => {
                     p.function = opcode.function;
                     p.gas_cost = opcode.gas_cost;
                     p.eip_size = decode_args_with_modrm(opcode, buffer, &mut p.args, false, modrm)? as u8;
                 },
-                JumpBehavior::Conditional => {
+                PipelineBehavior::Unpredictable => {
                     p.function = opcode.function;
                     p.gas_cost = opcode.gas_cost;
                     p.eip_size = decode_args_with_modrm(opcode, buffer, &mut p.args, false, modrm)? as u8;
                     eip += p.eip_size as u32;
                     stop_filling = true;
                 },
-                JumpBehavior::Relative => {
+                PipelineBehavior::RelativeJump => {
                     //todo: later follow jumps that can be predicted
                     //right now this is just copy-pasted from conditional jumps
                     p.function = opcode.function;
@@ -120,7 +120,7 @@ mod tests{
             .into_table(&mut table);
         define_opcode(0x03)
             .has_arg(ArgSource::JumpRel, ValueSize::Dword)
-            .is_conditional()
+            .is_unpredictable()
             .with_gas(50)
             .calls(test3_op)
             .into_table(&mut table);


### PR DESCRIPTION
Previously Mod R/M was only parsed as part of the argument parsing. This changes it so that Mod R/M decoding is done in the pipeline before the actual opcode is chosen. This is done to greatly simplify how group opcodes are represented (no more complicated bit fields in the opcode table index) as well as to allow for the opcode 0xF6, which uses a Mod R/M group to determine which opcode, and the set of arguments varies for 1 opcode to include an immediate where the other opcodes do not have this argument. This would've been impossible to express in the previous version. 

There is also some refactoring done such as to rename JumpBehavior to a more appropriate and informative PipelineBehavior name