### PR TITLE
Earlz/implement gas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.3.0"
+strum = "0.15.0"
+strum_macros = "0.15.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/benches/qx86_benchmark.rs
+++ b/benches/qx86_benchmark.rs
@@ -50,6 +50,8 @@ criterion_main!(benches);
 pub fn create_vm() -> VM{
     let mut vm = VM::default();
     vm.eip = CODE_MEM;
+    vm.gas_remaining = 1000000000;
+    vm.charger = GasCharger::test_schedule();
     vm.memory.add_memory(CODE_MEM, 0x10000).unwrap();
     vm.memory.add_memory(DATA_MEM, 0x10000).unwrap();
     vm

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,9 @@
 
 #[macro_use]
 extern crate lazy_static;
-
+extern crate strum;
+#[macro_use]
+extern crate strum_macros;
 
 pub mod structs;
 pub mod decoding;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -9,7 +9,7 @@ use crate::decoding::*;
 pub struct Pipeline{
     pub function: OpcodeFn,
     pub args: [OpArgument; MAX_ARGS],
-    pub gas_cost: GasCost,
+    pub gas_cost: u64,
     pub eip_size: u8,
     pub size_override: bool
 }
@@ -19,7 +19,7 @@ impl Default for Pipeline{
         Pipeline{
             function: nop,
             args: [OpArgument::default(), OpArgument::default(), OpArgument::default()],
-            gas_cost: GasCost::None,
+            gas_cost: 0,
             eip_size: 1,
             size_override: false
         }
@@ -35,35 +35,36 @@ pub fn clear_pipeline(pipeline: &mut [Pipeline]){
 pub fn fill_pipeline(vm: &VM, opcodes: &[OpcodeProperties], pipeline: &mut [Pipeline]) -> Result<(), VMError>{
     let mut eip = vm.eip;
     let mut stop_filling = false;
+    let mut running_gas = vm.gas_remaining;
     //writeable if in memory with top bit set
-    let writeable = vm.eip & 0x8000000 > 0;
+    let writeable = vm.eip & 0x80000000 > 0;
     clear_pipeline(pipeline);
     for n in 0..pipeline.len(){
         let mut p = &mut pipeline[n];
+        p.gas_cost = 0; //this can be reused, so make sure to clear previous
         if stop_filling {
             p.function = nop;
             p.eip_size = 0;
-            p.gas_cost = GasCost::None;
+            p.gas_cost = 0;
         }else{
             let buffer = vm.memory.get_sized_memory(eip, 16)?;
             //todo: handle 0x0F extension prefix and other prefixes
             let prop = &opcodes[buffer[0 as usize] as usize];
             let mut modrm = Option::None;
             let opcode = if prop.has_modrm{
+                p.gas_cost += vm.charger.cost(GasCost::ModRMSurcharge);
                 modrm = Some(ParsedModRM::from_bytes(buffer)?);
                 &prop.opcodes[modrm.unwrap().modrm.reg as usize]
             }else{
                 &prop.opcodes[0]
             };
+            p.function = opcode.function;
+            p.gas_cost += vm.charger.cost(opcode.gas_cost);
             match opcode.pipeline_behavior{
                 PipelineBehavior::None => {
-                    p.function = opcode.function;
-                    p.gas_cost = opcode.gas_cost;
                     p.eip_size = decode_args_with_modrm(opcode, buffer, &mut p.args, false, modrm)? as u8;
                 },
-                PipelineBehavior::Unpredictable => {
-                    p.function = opcode.function;
-                    p.gas_cost = opcode.gas_cost;
+                PipelineBehavior::Unpredictable | PipelineBehavior::UnpredictableNoGas => {
                     p.eip_size = decode_args_with_modrm(opcode, buffer, &mut p.args, false, modrm)? as u8;
                     eip += p.eip_size as u32;
                     stop_filling = true;
@@ -71,21 +72,32 @@ pub fn fill_pipeline(vm: &VM, opcodes: &[OpcodeProperties], pipeline: &mut [Pipe
                 PipelineBehavior::RelativeJump => {
                     //todo: later follow jumps that can be predicted
                     //right now this is just copy-pasted from conditional jumps
-                    p.function = opcode.function;
-                    p.gas_cost = opcode.gas_cost;
                     p.eip_size = decode_args_with_modrm(opcode, buffer, &mut p.args, false, modrm)? as u8;
                     eip += p.eip_size as u32;
                     stop_filling = true;
                 }
             };
+            p.gas_cost += match opcode.pipeline_behavior{
+                PipelineBehavior::Unpredictable => vm.charger.cost(GasCost::ConditionalBranch),
+                _ => 0
+            };
+            for i in 0..MAX_ARGS{
+                p.gas_cost += if p.args[i].is_memory{
+                    vm.charger.cost(GasCost::MemoryAccess)
+                }else{
+                    0
+                };
+            }
             eip += p.eip_size as u32;
         }
         if writeable {
             //if in writeable space, only use one pipeline slot at a time
             //otherwise, the memory we are decoding could be changed by an opcode within the pipeline
+            p.gas_cost += vm.charger.cost(GasCost::WriteableMemoryExec);
             stop_filling = true;
         }
-
+        running_gas = running_gas.saturating_sub(p.gas_cost);
+        stop_filling |= running_gas == 0;
     }
     Ok(())
 }
@@ -140,6 +152,7 @@ mod tests{
     fn test_simple_pipeline(){
         let opcodes = test_opcodes();
         let mut vm = VM::default();
+        vm.gas_remaining = 1;
         let vm_mem = vm.memory.add_memory(0x10000, 0x100).unwrap();
         vm.eip = 0x10000;
         let bytes = vec![
@@ -179,6 +192,7 @@ mod tests{
     fn test_cond_jump_pipeline(){
         let opcodes = test_opcodes();
         let mut vm = VM::default();
+        vm.gas_remaining = 1;
         let vm_mem = vm.memory.add_memory(0x10000, 0x100).unwrap();
         vm.eip = 0x10000;
         let bytes = vec![

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -204,6 +204,7 @@ impl Default for ArgLocation{
 #[derive(Copy, Clone)]
 pub struct OpArgument{
     pub location: ArgLocation,
+    pub is_memory: bool
 }
 
 
@@ -213,7 +214,8 @@ pub struct OpArgument{
 impl Default for OpArgument{
     fn default() -> OpArgument{
         OpArgument{
-            location: ArgLocation::None
+            location: ArgLocation::None,
+            is_memory: false
         }
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -5,10 +5,13 @@ use qx86::vm::*;
 
 pub const CODE_MEM:u32 = 0x10000;
 pub const DATA_MEM:u32 = 0x80000000;
+pub const INITIAL_GAS:u64 = 10000000;
 
 pub fn create_vm() -> VM{
     let mut vm = VM::default();
     vm.eip = CODE_MEM;
+    vm.charger = GasCharger::test_schedule();
+    vm.gas_remaining = INITIAL_GAS;
     vm.memory.add_memory(CODE_MEM, 0x1000).unwrap();
     vm.memory.add_memory(DATA_MEM, 0x1000).unwrap();
     vm
@@ -21,7 +24,7 @@ pub fn create_vm_with_asm(input: &str) -> VM{
     vm
 }
 
-pub fn execute_vm_asm(input: &str) -> VM{
+pub fn execute_vm_with_asm(input: &str) -> VM{
     let mut vm = create_vm_with_asm(input);
     assert!(vm.execute().unwrap());
     vm

--- a/tests/gas_tests.rs
+++ b/tests/gas_tests.rs
@@ -1,0 +1,23 @@
+extern crate qx86;
+mod common;
+
+use qx86::vm::*;
+use common::*;
+
+fn cost_from_list(charger: &GasCharger, costs: &[GasCost]) -> u64{
+    let mut cost = 0;
+    for c in costs{
+        cost += charger.cost(*c);
+    }
+    cost
+}
+
+
+#[test]
+fn test_hlt_usage(){
+    let vm = execute_vm_with_asm("
+        hlt");
+    //this should actually consume no gas
+    assert_eq!(vm.gas_remaining, INITIAL_GAS);
+}
+

--- a/tests/gas_tests.rs
+++ b/tests/gas_tests.rs
@@ -14,10 +14,53 @@ fn cost_from_list(charger: &GasCharger, costs: &[GasCost]) -> u64{
 
 
 #[test]
-fn test_hlt_usage(){
+fn test_hlt_gas(){
     let vm = execute_vm_with_asm("
         hlt");
     //this should actually consume no gas
     assert_eq!(vm.gas_remaining, INITIAL_GAS);
 }
 
+#[test]
+fn test_simple_gas(){
+    use GasCost::*;
+    //mov is VeryLow
+    let vm = execute_vm_with_asm("
+        mov eax, 0x80000000 ;VeryLow
+        mov ecx, [eax] ;VeryLow + Memory + ModRM
+        nop ;None
+        hlt ;None
+        ");
+    assert_eq!(vm.gas_remaining, INITIAL_GAS - cost_from_list(&vm.charger, &[VeryLow, VeryLow, MemoryAccess, ModRMSurcharge]));
+}
+
+//Need more tests here once more opcodes are implemented, especially jmp and jcc
+
+#[test]
+fn test_perfect_gas_amount(){
+    use GasCost::*;
+    let mut vm = create_vm_with_asm("
+        mov eax, 0x80000000 ;VeryLow
+        mov ecx, [eax] ;VeryLow + Memory + ModRM
+        nop ;None
+        hlt ;None
+        ");
+    vm.gas_remaining = cost_from_list(&vm.charger, &[VeryLow, VeryLow, MemoryAccess, ModRMSurcharge]);
+    vm.execute().unwrap();
+}
+
+#[test]
+fn test_out_of_gas(){
+    use GasCost::*;
+    let mut vm = create_vm_with_asm("
+        mov eax, 0x80000000 ;VeryLow -- size: 5
+        mov ecx, [eax] ;VeryLow + Memory + ModRM -- size: 2
+        nop ;None -- size: 1
+        hlt ;None -- size: 1
+        ");
+    vm.gas_remaining = cost_from_list(&vm.charger, &[VeryLow, VeryLow, MemoryAccess, ModRMSurcharge]) - 1;
+    let r = vm.execute();
+    assert_eq!(r.err().unwrap(), VMError::OutOfGas);
+    //should stop at the `mov ecx, [eax]`
+    assert_eq!(vm.eip, CODE_MEM + 5); 
+}

--- a/tests/simple_tests.rs
+++ b/tests/simple_tests.rs
@@ -36,7 +36,7 @@ fn test_simple_nop_hlt(){
 
 #[test]
 fn test_mov_hlt(){
-    let vm = execute_vm_asm("
+    let vm = execute_vm_with_asm("
     mov al, 0x11
     mov ah, 0x22
     mov dl, 0x33
@@ -49,7 +49,7 @@ fn test_mov_hlt(){
 #[test]
 fn test_mov(){
     //scratch memory: 0x80000000
-    let vm = execute_vm_asm("
+    let vm = execute_vm_with_asm("
         mov al, 0x11
         mov ecx, 0x80000000
         mov dword [ecx], 0x11223344

--- a/tests/simple_tests.rs
+++ b/tests/simple_tests.rs
@@ -16,7 +16,7 @@ fn test_undefined_opcode(){
         0x90
     ];
     vm.copy_into_memory(CODE_MEM, &bytes).unwrap();
-    assert!(vm.execute().err().unwrap() == VMError::InvalidOpcode);
+    assert_eq!(vm.execute().err().unwrap(), VMError::InvalidOpcode);
     assert_eq!(vm.error_eip, CODE_MEM + 2);
 }
 


### PR DESCRIPTION
This model basically does all gas computations in the pipelining stage, so that the actual logic of opcodes never needs to worry about charging gas. This can also work with dynamic gas cost opcodes (ie, `int` for system calls) by marking the opcode as Unpredictable/UnpredictableNoGas so that pipelining does not continue until after execution of that opcode