### PR TITLE
Add rep and movs opcode/prefix support

### DIFF
--- a/src/opcodes.rs
+++ b/src/opcodes.rs
@@ -1009,6 +1009,13 @@ lazy_static! {
             .with_rm_reg32()
             .with_rm16()
             .into_table(&mut ops); 
+        //0xA5 MOVSD/MOVSW
+        define_opcode(0xA5).calls(movs_native_word).with_gas(Low)
+            .into_table(&mut ops);
+        //0xA4 MOVSB
+        define_opcode(0xA4).calls(movsb).with_gas(Low)
+            .into_table(&mut ops);
+
 
         ops
     };

--- a/src/opcodes.rs
+++ b/src/opcodes.rs
@@ -1015,6 +1015,12 @@ lazy_static! {
         //0xA4 MOVSB
         define_opcode(0xA4).calls(movsb).with_gas(Low)
             .into_table(&mut ops);
+        //0xFD STD
+        define_opcode(0xFD).calls(set_direction).with_gas(VeryLow)
+            .into_table(&mut ops);
+        //0xFC CLD
+        define_opcode(0xFC).calls(clear_direction).with_gas(VeryLow)
+            .into_table(&mut ops);
 
 
         ops

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -992,7 +992,7 @@ fn decrement_regw(vm: &mut VM, reg: Reg32, size_override: bool) -> u32{
 pub fn repe(vm: &mut VM, pipeline: &Pipeline, hv: &mut dyn Hypervisor) -> Result<(), VMError>{
     let opcodes = &crate::opcodes::OPCODES;
     if rep_flag_opcodes(pipeline.opcode){
-
+        unimplemented!();
     }else if rep_no_flag_opcodes(pipeline.opcode){
         let function = opcodes[pipeline.opcode as usize].opcodes[0].function;
         let gas_cost = vm.charger.cost(opcodes[pipeline.opcode as usize].opcodes[0].gas_cost);
@@ -1016,6 +1016,13 @@ pub fn repe(vm: &mut VM, pipeline: &Pipeline, hv: &mut dyn Hypervisor) -> Result
     Ok(())
 }
 pub fn repne(vm: &mut VM, pipeline: &Pipeline, _hv: &mut dyn Hypervisor) -> Result<(), VMError>{
+    let opcodes = &crate::opcodes::OPCODES;
+    if rep_flag_opcodes(pipeline.opcode){
+        unimplemented!();
+    }else{
+        //note this prefix can not be used with non-flag using string instructions
+        return Err(VMError::InvalidOpcodeEncoding);
+    }
     Ok(())
 }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1023,14 +1023,24 @@ pub fn movs_native_word(vm: &mut VM, pipeline: &Pipeline, hv: &mut dyn Hyperviso
     //[EDI] . [ESI]
     if pipeline.size_override{
         vm.set_mem(vm.reg32(Reg32::EDI), SizedValue::Word(vm.get_mem(vm.reg32(Reg32::ESI), ValueSize::Word)?.u16_exact()?))?;
+        let d = if vm.flags.direction{
+            (-2i32) as u32
+        }else{
+            2
+        };
         //todo DF
-        vm.set_reg32(Reg32::EDI, vm.reg32(Reg32::EDI).wrapping_add(2));
-        vm.set_reg32(Reg32::ESI, vm.reg32(Reg32::ESI).wrapping_add(2));
+        vm.set_reg32(Reg32::EDI, vm.reg32(Reg32::EDI).wrapping_add(d));
+        vm.set_reg32(Reg32::ESI, vm.reg32(Reg32::ESI).wrapping_add(d));
     }else{
         vm.set_mem(vm.reg32(Reg32::EDI), SizedValue::Dword(vm.get_mem(vm.reg32(Reg32::ESI), ValueSize::Dword)?.u32_exact()?))?;
         //todo DF
-        vm.set_reg32(Reg32::EDI, vm.reg32(Reg32::EDI).wrapping_add(4));
-        vm.set_reg32(Reg32::ESI, vm.reg32(Reg32::ESI).wrapping_add(4));
+        let d = if vm.flags.direction{
+            (-4i32) as u32
+        }else{
+            4
+        };
+        vm.set_reg32(Reg32::EDI, vm.reg32(Reg32::EDI).wrapping_add(d));
+        vm.set_reg32(Reg32::ESI, vm.reg32(Reg32::ESI).wrapping_add(d));
     }
     Ok(())
 }
@@ -1038,7 +1048,20 @@ pub fn movsb(vm: &mut VM, pipeline: &Pipeline, hv: &mut dyn Hypervisor) -> Resul
     //[EDI] . [ESI]
     vm.set_mem(vm.reg32(Reg32::EDI), SizedValue::Byte(vm.get_mem(vm.reg32(Reg32::ESI), ValueSize::Byte)?.u8_exact()?))?;
     //todo DF
-    vm.set_reg32(Reg32::EDI, vm.reg32(Reg32::EDI).wrapping_add(1));
-    vm.set_reg32(Reg32::ESI, vm.reg32(Reg32::ESI).wrapping_add(1));
+    let d = if vm.flags.direction{
+        (-1i32) as u32
+    }else{
+        1
+    };
+    vm.set_reg32(Reg32::EDI, vm.reg32(Reg32::EDI).wrapping_add(d));
+    vm.set_reg32(Reg32::ESI, vm.reg32(Reg32::ESI).wrapping_add(d));
+    Ok(())
+}
+pub fn set_direction(vm: &mut VM, _pipeline: &Pipeline, _hv: &mut dyn Hypervisor) -> Result<(), VMError>{
+    vm.flags.direction = true;
+    Ok(())
+}
+pub fn clear_direction(vm: &mut VM, _pipeline: &Pipeline, _hv: &mut dyn Hypervisor) -> Result<(), VMError>{
+    vm.flags.direction = false;
     Ok(())
 }

--- a/tests/simple_tests.rs
+++ b/tests/simple_tests.rs
@@ -1032,3 +1032,28 @@ fn test_rep_movsb() {
     assert_eq!(vm.reg32(Reg32::EDI), 0x80000004);
     assert_eq!(vm.reg32(Reg32::ECX), 0);
 }
+
+#[test]
+fn test_rep_movsw() {
+    let vm = execute_vm_with_asm("
+        mov edi, 0x80000000
+        mov dword [edi], 0x11223344
+        mov dword [edi + 4], 0xaabbccdd
+        mov esi, 0x80000002
+        mov ecx, 4
+        rep movsw
+        mov eax, [0x80000000]
+        mov ebx, [0x80000004]
+        hlt");      
+    /*
+        ; memory before
+        ; 44 33 22 11 dd cc bb aa
+        ; memory after at 0..8
+        ; 22 11 dd cc bb aa 00 00
+    */
+    assert_eq!(vm.reg32(Reg32::EAX), 0xccdd1122);
+    assert_eq!(vm.reg32(Reg32::EBX), 0x0000aabb);
+    assert_eq!(vm.reg32(Reg32::ESI), 0x8000000a);
+    assert_eq!(vm.reg32(Reg32::EDI), 0x80000008);
+    assert_eq!(vm.reg32(Reg32::ECX), 0);
+}

--- a/tests/simple_tests.rs
+++ b/tests/simple_tests.rs
@@ -1034,6 +1034,33 @@ fn test_rep_movsb() {
 }
 
 #[test]
+fn test_rep_movsb_df() {
+    let vm = execute_vm_with_asm("
+        mov edi, 0x80000000
+        mov dword [edi], 0x11223344
+        mov dword [edi + 4], 0xaabbccdd
+        mov esi, 0x80000006
+        mov edi, 0x80000004 
+        mov ecx, 4
+        std
+        rep movsb
+        mov eax, [0x80000000]
+        mov ebx, [0x80000004]
+        hlt");      
+    /*
+        ; memory before
+        ; 44 33 22 11 dd cc bb aa
+        ; memory after
+        ; 44 cc bb cc bb cc bb aa
+    */
+    assert_eq!(vm.reg32(Reg32::EAX), 0xccbbcc44);
+    assert_eq!(vm.reg32(Reg32::EBX), 0xaabbccbb);
+    assert_eq!(vm.reg32(Reg32::ESI), 0x80000002);
+    assert_eq!(vm.reg32(Reg32::EDI), 0x80000000);
+    assert_eq!(vm.reg32(Reg32::ECX), 0);
+}
+
+#[test]
 fn test_rep_movsw() {
     let vm = execute_vm_with_asm("
         mov edi, 0x80000000
@@ -1055,5 +1082,27 @@ fn test_rep_movsw() {
     assert_eq!(vm.reg32(Reg32::EBX), 0x0000aabb);
     assert_eq!(vm.reg32(Reg32::ESI), 0x8000000a);
     assert_eq!(vm.reg32(Reg32::EDI), 0x80000008);
+    assert_eq!(vm.reg32(Reg32::ECX), 0);
+}
+
+#[test]
+fn test_rep_movsd() {
+    let vm = execute_vm_with_asm("
+        mov esi, 0x80000000
+        mov dword [esi], 0x11223344
+        mov dword [esi + 4], 0xaabbccdd
+        mov dword [esi + 8], 0x55667788
+        mov edi, 0x80000004
+        mov ecx, 3
+        rep movsd
+        mov eax, [0x80000004]
+        mov ebx, [0x80000008]
+        mov edx, [0x8000000C]
+        hlt");      
+    assert_eq!(vm.reg32(Reg32::EAX), 0x11223344);
+    assert_eq!(vm.reg32(Reg32::EBX), 0x11223344);
+    assert_eq!(vm.reg32(Reg32::EDX), 0x11223344);
+    assert_eq!(vm.reg32(Reg32::ESI), 0x8000000C);
+    assert_eq!(vm.reg32(Reg32::EDI), 0x80000010);
     assert_eq!(vm.reg32(Reg32::ECX), 0);
 }

--- a/tests/simple_tests.rs
+++ b/tests/simple_tests.rs
@@ -1006,3 +1006,29 @@ fn test_movzx() {
     assert_eq!(vm.reg32(Reg32::EDX), 0xFFFFFEDC);
     assert_eq!(vm.reg32(Reg32::ESI), 0xFEDC);
 }
+
+#[test]
+fn test_rep_movsb() {
+    let vm = execute_vm_with_asm("
+        mov edi, 0x80000000
+        mov esi, 0x80000002
+        mov dword [esi], 0x11223344
+        mov dword [edi], 0xaabbccdd
+        mov ecx, 4
+        rep movsb
+        mov eax, [0x80000000]
+        mov ebx, [0x80000002]
+        hlt");      
+    /*
+        ; memory before
+        ; 00 00 44 33 22 11 -> dd cc bb aa 22 11
+        ; aa bb cc dd 22 11
+        ; memory after at 8..0
+        ; bb aa 22 11
+    */
+    assert_eq!(vm.reg32(Reg32::EAX), 0x1122aabb);
+    assert_eq!(vm.reg32(Reg32::EBX), 0x11221122);
+    assert_eq!(vm.reg32(Reg32::ESI), 0x80000006);
+    assert_eq!(vm.reg32(Reg32::EDI), 0x80000004);
+    assert_eq!(vm.reg32(Reg32::ECX), 0);
+}


### PR DESCRIPTION
This adds rep and movs support and also adds the cld/std opcodes for changing the direction flag. repe/repne support is currently `unimplemented!()` and will be added in a later PR when a proper opcode such as CMPS is also implemented so that it can be easily tested 